### PR TITLE
fix/serialization

### DIFF
--- a/Source/SVONavigation/Public/SVOVersion.h
+++ b/Source/SVONavigation/Public/SVOVersion.h
@@ -5,5 +5,6 @@ enum class ESVOVersion : uint8
     Initial = 1,
     NoVoxelExponent = 2,
 
+    MinCompatible = NoVoxelExponent,
     Latest = NoVoxelExponent
 };


### PR DESCRIPTION
- Added MinCompatible value to ESVOVersion
- Use same way of handling incompatible navmesh data as in RecastNavMesh
