### PR TITLE
feature/pathfinding debug node extent

### DIFF
--- a/Source/SVONavigation/Private/SVOBoundsNavigationData.cpp
+++ b/Source/SVONavigation/Private/SVOBoundsNavigationData.cpp
@@ -244,6 +244,16 @@ float FSVOBoundsNavigationData::GetLayerInverseRatio( const LayerIndex layer_ind
     return 1.0f - GetLayerRatio( layer_index );
 }
 
+float FSVOBoundsNavigationData::GetVoxelHalfExtentFromLink( FSVOOctreeLink link ) const
+{
+    if ( link.LayerIndex == 0 )
+    {
+        return SVOData.GetLeaves().GetLeafSubNodeHalfExtent();
+    }
+
+    return SVOData.GetLayer( link.LayerIndex ).GetVoxelHalfExtent();
+}
+
 void FSVOBoundsNavigationData::GenerateNavigationData( const FBox & volume_bounds, const FSVOBoundsNavigationDataGenerationSettings & generation_settings )
 {
     QUICK_SCOPE_CYCLE_COUNTER( STAT_SVOBoundsNavigationData_GenerateNavigationData );
@@ -346,7 +356,7 @@ void FSVOBoundsNavigationData::FirstPassRasterization()
         for ( MortonCode node_index = 0; node_index < layer_max_node_count; ++node_index )
         {
             const auto position = GetNodePosition( 1, node_index );
-            
+
             if ( IsPositionOccluded( position, layer_voxel_half_extent ) )
             {
                 layer_zero.AddBlockedNode( node_index );
@@ -396,7 +406,7 @@ void FSVOBoundsNavigationData::RasterizeInitialLayer()
     LeafIndex leaf_index = 0;
 
     const auto layer_one_blocked_node_count = SVOData.GetLayer( 1 ).GetBlockedNodesCount();
-    layer_zero_nodes.Reserve( layer_one_blocked_node_count  * 8 );
+    layer_zero_nodes.Reserve( layer_one_blocked_node_count * 8 );
 
     const auto layer_max_node_count = layer_zero.GetMaxNodeCount();
     const auto layer_voxel_half_size = layer_zero.GetVoxelHalfExtent();

--- a/Source/SVONavigation/Private/SVOPathFindingAlgorithm.cpp
+++ b/Source/SVONavigation/Private/SVOPathFindingAlgorithm.cpp
@@ -81,7 +81,7 @@ void FSVOPathFinderDebugNodeCost::Reset()
 
 void FSVOPathFinderDebugInfos::Reset()
 {
-    LastLastProcessedSingleNode.Reset();
+    LastProcessedSingleNode.Reset();
     ProcessedNeighbors.Reset();
     Iterations = 0;
     VisitedNodes = 0;
@@ -143,15 +143,15 @@ void FSVOPathFindingAStarObserver_GenerateDebugInfos::OnProcessSingleNode( const
 {
     if ( node.ParentRef.IsValid() )
     {
-        DebugInfos.LastLastProcessedSingleNode.From = FSVOLinkWithLocation( node.ParentRef, *Stepper.GetParameters().BoundsNavigationData );
+        DebugInfos.LastProcessedSingleNode.From = FSVOLinkWithLocation( node.ParentRef, *Stepper.GetParameters().BoundsNavigationData );
     }
     else
     {
-        DebugInfos.LastLastProcessedSingleNode.From = FSVOLinkWithLocation( FSVOOctreeLink::InvalidLink(), Stepper.GetParameters().StartLocation );
+        DebugInfos.LastProcessedSingleNode.From = FSVOLinkWithLocation( FSVOOctreeLink::InvalidLink(), Stepper.GetParameters().StartLocation );
     }
 
-    DebugInfos.LastLastProcessedSingleNode.To = FSVOLinkWithLocation( node.NodeRef, *Stepper.GetParameters().BoundsNavigationData );
-    DebugInfos.LastLastProcessedSingleNode.Cost = node.TotalCost;
+    DebugInfos.LastProcessedSingleNode.To = FSVOLinkWithLocation( node.NodeRef, *Stepper.GetParameters().BoundsNavigationData );
+    DebugInfos.LastProcessedSingleNode.Cost = node.TotalCost;
 
     DebugInfos.ProcessedNeighbors.Reset();
 

--- a/Source/SVONavigation/Public/SVOBoundsNavigationData.h
+++ b/Source/SVONavigation/Public/SVOBoundsNavigationData.h
@@ -32,6 +32,7 @@ public:
     void GetNeighbors( TArray< FSVOOctreeLink > & neighbors, const FSVOOctreeLink & link ) const;
     float GetLayerRatio( LayerIndex layer_index ) const;
     float GetLayerInverseRatio( LayerIndex layer_index ) const;
+    float GetVoxelHalfExtentFromLink( FSVOOctreeLink link ) const;
 
     void GenerateNavigationData( const FBox & volume_bounds, const FSVOBoundsNavigationDataGenerationSettings & generation_settings );
     void Serialize( FArchive & archive, const ESVOVersion version );

--- a/Source/SVONavigation/Public/SVOPathFinderTest.h
+++ b/Source/SVONavigation/Public/SVOPathFinderTest.h
@@ -14,6 +14,8 @@ class USphereComponent;
 class ASVOPathFinderTest;
 class USVOPathFindingRenderingComponent;
 
+class FSVOPathFindingAlgorithmStepper;
+
 USTRUCT()
 struct SVONAVIGATION_API FSVOPathRenderingDebugDrawOptions
 {
@@ -21,10 +23,10 @@ struct SVONAVIGATION_API FSVOPathRenderingDebugDrawOptions
 
     FSVOPathRenderingDebugDrawOptions() :
         bDrawOnlyWhenSelected( false ),
+        bDrawNodes( true ),
+        bDrawCosts( false ),
         bDrawLastProcessedNode( true ),
-        bDrawLastProcessedNodeCost( false ),
         bDrawLastProcessedNeighbors( true ),
-        bDrawNeighborsCost( false ),
         bDrawBestPath( true )
     {}
 
@@ -32,16 +34,16 @@ struct SVONAVIGATION_API FSVOPathRenderingDebugDrawOptions
     uint8 bDrawOnlyWhenSelected : 1;
 
     UPROPERTY( EditAnywhere )
-    uint8 bDrawLastProcessedNode : 1;
+    uint8 bDrawNodes : 1;
 
-    UPROPERTY( EditAnywhere, meta = ( EditCondition = "bDrawLastProcessedNode" ) )
-    uint8 bDrawLastProcessedNodeCost : 1;
+    UPROPERTY( EditAnywhere )
+    uint8 bDrawCosts : 1;
+
+    UPROPERTY( EditAnywhere )
+    uint8 bDrawLastProcessedNode : 1;
 
     UPROPERTY( EditAnywhere )
     uint8 bDrawLastProcessedNeighbors : 1;
-
-    UPROPERTY( EditAnywhere, meta = ( EditCondition = "bDrawNeighborsCost" ) )
-    uint8 bDrawNeighborsCost : 1;
 
     UPROPERTY( EditAnywhere )
     uint8 bDrawBestPath : 1;
@@ -55,6 +57,7 @@ struct SVONAVIGATION_API FSVOPathFindingSceneProxyData final : public TSharedFro
     FVector EndLocation;
     FSVOPathFinderDebugInfos DebugInfos;
     TOptional< EGraphAStarResult > PathFindingResult;
+    TSharedPtr< const FSVOPathFindingAlgorithmStepper > Stepper;
 };
 
 class SVONAVIGATION_API FSVOPathFindingSceneProxy final : public FDebugRenderSceneProxy
@@ -66,7 +69,7 @@ public:
 
     SIZE_T GetTypeHash() const override;
     FPrimitiveViewRelevance GetViewRelevance( const FSceneView * view ) const override;
-    void GetDynamicMeshElements( const TArray<const FSceneView *> & views, const FSceneViewFamily & view_family, uint32 visibility_map, FMeshElementCollector & collector ) const override;
+    void GetDynamicMeshElements( const TArray< const FSceneView * > & views, const FSceneViewFamily & view_family, uint32 visibility_map, FMeshElementCollector & collector ) const override;
 
 private:
     bool SafeIsActorSelected() const;
@@ -148,6 +151,7 @@ public:
     FVector GetEndLocation() const;
     const FSVOPathFinderDebugInfos & GetPathFinderDebugInfos() const;
     const FSVOPathRenderingDebugDrawOptions & GetDebugDrawOptions() const;
+    const TSharedPtr< FSVOPathFindingAlgorithmStepper > & GetStepper() const;
     ESVOPathFindingAlgorithmStepperStatus GetStepperLastStatus() const;
     EGraphAStarResult GetPathFindingResult() const;
     void BeginDestroy() override;
@@ -236,6 +240,11 @@ FORCEINLINE const FSVOPathFinderDebugInfos & ASVOPathFinderTest::GetPathFinderDe
 FORCEINLINE const FSVOPathRenderingDebugDrawOptions & ASVOPathFinderTest::GetDebugDrawOptions() const
 {
     return DebugDrawOptions;
+}
+
+FORCEINLINE const TSharedPtr< FSVOPathFindingAlgorithmStepper > & ASVOPathFinderTest::GetStepper() const
+{
+    return Stepper;
 }
 
 FORCEINLINE ESVOPathFindingAlgorithmStepperStatus ASVOPathFinderTest::GetStepperLastStatus() const

--- a/Source/SVONavigation/Public/SVOPathFindingAlgorithm.h
+++ b/Source/SVONavigation/Public/SVOPathFindingAlgorithm.h
@@ -59,7 +59,7 @@ struct SVONAVIGATION_API FSVOPathFinderDebugInfos
 
     void Reset();
 
-    FSVOPathFinderDebugNodeCost LastLastProcessedSingleNode;
+    FSVOPathFinderDebugNodeCost LastProcessedSingleNode;
     TArray< FSVOPathFinderDebugNodeCost > ProcessedNeighbors;
     FNavigationPath CurrentBestPath;
 


### PR DESCRIPTION
- Changed pathfinding stepper debug visualization options to show the nodes it's exploring as cubes
- Moved non-const functions from FSVOLayers and FSVOLeaves private and made those classes friend of the classes which need non-const access
