### PR TITLE
fix/generator_update_navigation_bounds_crash

### DIFF
--- a/Source/SVONavigation/Private/SVONavigationData.cpp
+++ b/Source/SVONavigation/Private/SVONavigationData.cpp
@@ -580,7 +580,7 @@ FBox ASVONavigationData::GetBoundingBox() const
 
 void ASVONavigationData::RemoveDataInBounds( const FBox & bounds )
 {
-    VolumeNavigationData.RemoveAll( [ &bounds ]( const FSVOVolumeNavigationData & data ) {
+    VolumeNavigationData.RemoveAllSwap( [ &bounds ]( const FSVOVolumeNavigationData & data ) {
         return data.GetVolumeBounds() == bounds;
     } );
 }

--- a/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
+++ b/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
@@ -263,18 +263,7 @@ void FSVONavigationDataGenerator::UpdateNavigationBounds()
                 }
 
                 // Remove the existing navigation bounds which don't match the new navigation bounds
-                // :TODO: Avoid copying data
-                const auto & existing_navigation_bounds = NavigationData.GetVolumeNavigationData();
-
-                for ( const auto & existing_bounds : existing_navigation_bounds )
-                {
-                    if ( RegisteredNavigationBounds.FindByPredicate( [ &existing_bounds ]( const FBox & registered_bounds ) {
-                             return registered_bounds == existing_bounds.GetVolumeBounds();
-                         } ) == nullptr )
-                    {
-                        NavigationData.RemoveDataInBounds( existing_bounds.GetVolumeBounds() );
-                    }
-                }
+                NavigationData.RemoveDataInBounds( RegisteredNavigationBounds );
             }
             TotalNavigationBounds = bounds_sum;
         }

--- a/Source/SVONavigation/Public/SVONavigationData.h
+++ b/Source/SVONavigation/Public/SVONavigationData.h
@@ -107,6 +107,16 @@ public:
     void RequestDrawingUpdate( bool force = false );
     FBox GetBoundingBox() const;
     void RemoveDataInBounds( const FBox & bounds );
+
+    template< typename _ALLOCATOR_TYPE_ >
+    void RemoveDataInBounds( const TArray< FBox, _ALLOCATOR_TYPE_ > & bounds_array )
+    {
+        for ( const auto & bounds : bounds_array )
+        {
+            RemoveDataInBounds( bounds );
+        }
+    }
+
     void AddVolumeNavigationData( FSVOVolumeNavigationData data );
     const FSVOVolumeNavigationData * GetVolumeNavigationDataContainingPoints( const TArray< FVector > & points ) const;
     void UpdateNavVersion();


### PR DESCRIPTION
- Use RemoveAllSwap instead of RemoveAll
- Created RemoveDataInBounds that takes an array of bounds to delete from
- Use new function in FSVONavigationDataGenerator::UpdateNavigationBounds
