### PR TITLE
fix/fail_path_when_no_neighbor

### DIFF
--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm.cpp
@@ -37,7 +37,7 @@ ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper::Step( EGr
         }
         case ESVOPathFindingAlgorithmState::ProcessNeighbor:
         {
-            return ProcessNeighbor();
+            return ProcessNeighbor( result );
         }
         case ESVOPathFindingAlgorithmState::Ended:
         {

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_AStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_AStar.cpp
@@ -144,9 +144,15 @@ ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_AStar::Pro
     return ESVOPathFindingAlgorithmStepperStatus::MustContinue;
 }
 
-ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_AStar::ProcessNeighbor()
+ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_AStar::ProcessNeighbor( EGraphAStarResult & result )
 {
     NeighborIndexIncrement neighbor_index_increment( Neighbors, NeighborIndex, State );
+
+    if ( !Neighbors.IsValidIndex( NeighborIndex ) )
+    {
+        result = SearchFail;
+        return ESVOPathFindingAlgorithmStepperStatus::IsStopped;
+    }
 
     const auto neighbor_address = Neighbors[ NeighborIndex ];
 

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.cpp
@@ -80,7 +80,7 @@ ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_LazyThetaS
     return ESVOPathFindingAlgorithmStepperStatus::MustContinue;
 }
 
-ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_LazyThetaStar::ProcessNeighbor()
+ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_LazyThetaStar::ProcessNeighbor( EGraphAStarResult & result )
 {
     NeighborIndexIncrement neighbor_index_increment( Neighbors, NeighborIndex, State );
 

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
@@ -24,9 +24,15 @@ ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_ThetaStar:
 }
 
 // Pretty much the same as A* except we try to check if there's a line of sight between the parent of the current node and the neighbor, and path from that parent to the neighbor if there is
-ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_ThetaStar::ProcessNeighbor()
+ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_ThetaStar::ProcessNeighbor( EGraphAStarResult & result )
 {
     NeighborIndexIncrement neighbor_index_increment( Neighbors, NeighborIndex, State );
+
+    if ( !Neighbors.IsValidIndex( NeighborIndex ) )
+    {
+        result = SearchFail;
+        return ESVOPathFindingAlgorithmStepperStatus::IsStopped;
+    }
 
     const auto neighbor_node_address = Neighbors[ NeighborIndex ];
 

--- a/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm.h
+++ b/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm.h
@@ -46,7 +46,7 @@ public:
 protected:
     virtual ESVOPathFindingAlgorithmStepperStatus Init( EGraphAStarResult & result ) = 0;
     virtual ESVOPathFindingAlgorithmStepperStatus ProcessSingleNode( EGraphAStarResult & result ) = 0;
-    virtual ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor() = 0;
+    virtual ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor( EGraphAStarResult & result ) = 0;
     virtual ESVOPathFindingAlgorithmStepperStatus Ended( EGraphAStarResult & result ) = 0;
 
     void SetState( ESVOPathFindingAlgorithmState new_state );

--- a/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_AStar.h
+++ b/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_AStar.h
@@ -14,7 +14,7 @@ public:
 protected:
     ESVOPathFindingAlgorithmStepperStatus Init( EGraphAStarResult & result ) override;
     ESVOPathFindingAlgorithmStepperStatus ProcessSingleNode( EGraphAStarResult & result ) override;
-    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor() override;
+    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor( EGraphAStarResult & result ) override;
     ESVOPathFindingAlgorithmStepperStatus Ended( EGraphAStarResult & result ) override;
 
     void FillNodeAddressNeighbors( const FSVONodeAddress & node_address );

--- a/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.h
+++ b/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.h
@@ -14,7 +14,7 @@ public:
 
 protected:
     ESVOPathFindingAlgorithmStepperStatus ProcessSingleNode( EGraphAStarResult & result ) override;
-    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor() override;
+    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor( EGraphAStarResult & result ) override;
 };
 
 UCLASS( Blueprintable )

--- a/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_ThetaStar.h
+++ b/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithm_ThetaStar.h
@@ -27,7 +27,7 @@ public:
 
 protected:
     ESVOPathFindingAlgorithmStepperStatus Init( EGraphAStarResult & result ) override;
-    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor() override;
+    ESVOPathFindingAlgorithmStepperStatus ProcessNeighbor( EGraphAStarResult & result ) override;
     ESVOPathFindingAlgorithmStepperStatus Ended( EGraphAStarResult & result ) override;
     bool HasLineOfSight( FSVONodeAddress from, FSVONodeAddress to ) const;
 


### PR DESCRIPTION
Fail pathfinding when no neighbor can be found for a cell
