### PR TITLE
fix_neighbors

### DIFF
--- a/Source/SVONavigation/Private/PathFinding/SVONavigationQueryFilterSettings.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVONavigationQueryFilterSettings.cpp
@@ -1,13 +1,9 @@
 #include "Pathfinding/SVONavigationQueryFilterSettings.h"
 
-#include "PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.h"
-#include "PathFinding/SVOPathHeuristicCalculator.h"
-#include "PathFinding/SVOPathTraversalCostCalculator.h"
-
 FSVONavigationQueryFilterSettings::FSVONavigationQueryFilterSettings() :
-    PathFinder( NewObject< USVOPathFindingAlgorithmLazyThetaStar >() ),
-    TraversalCostCalculator( NewObject< USVOPathCostCalculator_Fixed >() ),
-    HeuristicCalculator( NewObject< USVOPathHeuristicCalculator_Manhattan >() ),
+    PathFinder( nullptr ),
+    TraversalCostCalculator( nullptr ),
+    HeuristicCalculator( nullptr ),
     HeuristicScale( 1.0f ),
     bUseNodeSizeCompensation( true )
 {

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFinder.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFinder.cpp
@@ -72,8 +72,11 @@ ENavigationQueryResult::Type FSVOPathFinder::GetPath( FSVONavigationPath & navig
 
         if ( const auto * path_finder = GetPathFindingAlgorithm( navigation_query_filter_copy ) )
         {
-            const FSVOPathFindingParameters params( *volume_navigation_data, start_location, end_location, *navigation_query_filter_copy );
-            return path_finder->GetPath( navigation_path, params );
+            const auto params = FSVOPathFindingParameters::Initialize( *volume_navigation_data, start_location, end_location, *nav_query_filter );
+            if ( params.IsSet() )
+            {
+                return path_finder->GetPath( navigation_path, params.GetValue() );
+            }
         }
     }
 
@@ -86,8 +89,12 @@ TSharedPtr< FSVOPathFindingAlgorithmStepper > FSVOPathFinder::GetDebugPathSteppe
     {
         if ( const auto * volume_navigation_data = navigation_data.GetVolumeNavigationDataContainingPoints( { start_location, end_location } ) )
         {
-            const FSVOPathFindingParameters params( *volume_navigation_data, start_location, end_location, *nav_query_filter );
-            return path_finder->GetDebugPathStepper( debug_infos, params );
+            const auto params = FSVOPathFindingParameters::Initialize( *volume_navigation_data, start_location, end_location, *nav_query_filter );
+
+            if ( params.IsSet() )
+            {
+                return path_finder->GetDebugPathStepper( debug_infos, params.GetValue() );
+            }
         }
     }
 

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFinder.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFinder.cpp
@@ -72,7 +72,7 @@ ENavigationQueryResult::Type FSVOPathFinder::GetPath( FSVONavigationPath & navig
 
         if ( const auto * path_finder = GetPathFindingAlgorithm( navigation_query_filter_copy ) )
         {
-            const auto params = FSVOPathFindingParameters::Initialize( *volume_navigation_data, start_location, end_location, *nav_query_filter );
+            const auto params = FSVOPathFindingParameters::Initialize( *volume_navigation_data, start_location, end_location, *navigation_query_filter_copy );
             if ( params.IsSet() )
             {
                 return path_finder->GetPath( navigation_path, params.GetValue() );

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFinderTest.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFinderTest.cpp
@@ -32,7 +32,7 @@ void FSVOPathFindingSceneProxyData::GatherData( const ASVOPathFinderTest & path_
 FSVOPathFindingSceneProxy::FSVOPathFindingSceneProxy( const UPrimitiveComponent & component, const FSVOPathFindingSceneProxyData & proxy_data ) :
     FDebugRenderSceneProxy( &component )
 {
-    DrawType = SolidAndWireMeshes;
+    DrawType = WireMesh;
     TextWithoutShadowDistance = 1500;
     bWantsSelectionOutline = false;
     ViewFlagName = TEXT( "Navigation" );

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFinderTest.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFinderTest.cpp
@@ -329,6 +329,8 @@ void ASVOPathFinderTest::UpdateDrawing()
 
 void ASVOPathFinderTest::InitPathFinding()
 {
+    Stepper.Reset();
+
     if ( UNavigationSystemV1 * navigation_system = UNavigationSystemV1::GetCurrent( GetWorld() ) )
     {
         if ( auto * navigation_data = navigation_system->GetNavDataForProps( NavAgentProperties ) )
@@ -343,7 +345,14 @@ void ASVOPathFinderTest::InitPathFinding()
                     const auto navigation_query_filter = UNavigationQueryFilter::GetQueryFilter( *svo_navigation_data, this, NavigationQueryFilter );
                     Stepper = FSVOPathFinder::GetDebugPathStepper( PathFinderDebugInfos, *svo_navigation_data, path_start, path_end, navigation_query_filter );
 
+                    if ( !Stepper.IsValid() )
+                    {
+                        return;
+                    }
+
                     PathFinderDebugInfos.Reset();
+                    PathFinderDebugInfos.StartNodeAddress = Stepper->GetParameters().StartNodeAddress.ToString();
+                    PathFinderDebugInfos.EndNodeAddress = Stepper->GetParameters().EndNodeAddress.ToString();
                     NavigationPath.ResetForRepath();
                     LastStatus = ESVOPathFindingAlgorithmStepperStatus::MustContinue;
                     PathFindingResult = SearchFail;
@@ -415,6 +424,11 @@ void ASVOPathFinderTest::AutoCompleteUntilNextNode()
 {
     InitPathFindingIfNotDone();
 
+    if ( !Stepper.IsValid() )
+    {
+        return;
+    }
+
     if ( LastStatus != ESVOPathFindingAlgorithmStepperStatus::IsStopped )
     {
         do
@@ -431,6 +445,11 @@ void ASVOPathFinderTest::AutoCompleteUntilNextNode()
 void ASVOPathFinderTest::AutoCompleteInstantly()
 {
     InitPathFindingIfNotDone();
+
+    if ( !Stepper.IsValid() )
+    {
+        return;
+    }
 
     if ( LastStatus != ESVOPathFindingAlgorithmStepperStatus::IsStopped )
     {

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmObservers.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmObservers.cpp
@@ -17,13 +17,15 @@ namespace
         const auto path_points_size = node_addresses.Num() + 1;
 
         path_points.Reset( path_points_size );
+
+        ensureAlways( node_addresses[ 0 ].NodeAddress == params.StartNodeAddress );
         path_points.Emplace( params.StartLocation );
 
         path_point_costs.Reset( path_points_size );
 
         const auto & bounds_data = params.VolumeNavigationData;
 
-        for ( auto index = 0; index < node_addresses.Num() - 1; index++ )
+        for ( auto index = 1; index < node_addresses.Num() - 1; index++ )
         {
             const auto address_with_cost = node_addresses[ index ];
             path_points.Emplace( bounds_data.GetNodePositionFromAddress( address_with_cost.NodeAddress, true ) );

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmObservers.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmObservers.cpp
@@ -5,6 +5,8 @@
 
 #include <NavigationPath.h>
 
+DEFINE_LOG_CATEGORY_STATIC( LogSVODebugPathStepper, Verbose, Verbose )
+
 namespace
 {
     void BuildPath( FSVONavigationPath & path, const FSVOPathFindingParameters & params, const TArray< FSVOPathFinderNodeAddressWithCost > & node_addresses, const bool add_end_location )
@@ -75,6 +77,8 @@ void FSVOPathFindingAStarObserver_GenerateDebugInfos::OnProcessSingleNode( const
     DebugInfos.LastProcessedSingleNode.To = FSVONodeAddressWithLocation( node.NodeRef, Stepper.GetParameters().VolumeNavigationData );
     DebugInfos.LastProcessedSingleNode.Cost = node.TotalCost;
 
+    UE_LOG( LogSVODebugPathStepper, Verbose, TEXT( "OnProcessSingleNode From [%s] To [%s] with cost [%s]" ), *node.NodeRef.ToString(), *DebugInfos.LastProcessedSingleNode.To.NodeAddress.ToString(), *FString::SanitizeFloat( node.TotalCost ) );
+
     DebugInfos.ProcessedNeighbors.Reset();
 
     DebugInfos.Iterations++;
@@ -90,12 +94,16 @@ void FSVOPathFindingAStarObserver_GenerateDebugInfos::OnProcessNeighbor( const F
 {
     DebugInfos.ProcessedNeighbors.Emplace( FSVONodeAddressWithLocation( parent.NodeRef, Stepper.GetParameters().VolumeNavigationData ), FSVONodeAddressWithLocation( neighbor.NodeRef, Stepper.GetParameters().VolumeNavigationData ), cost, true );
     DebugInfos.VisitedNodes++;
+
+    UE_LOG( LogSVODebugPathStepper, Verbose, TEXT( "OnProcessNeighbor From [%s] To [%s] with cost [%s]" ), *parent.NodeRef.ToString(), *neighbor.NodeRef.ToString(), *FString::SanitizeFloat( cost ) );
 }
 
 void FSVOPathFindingAStarObserver_GenerateDebugInfos::OnProcessNeighbor( const FGraphAStarDefaultNode< FSVOVolumeNavigationData > & neighbor )
 {
     DebugInfos.ProcessedNeighbors.Emplace( FSVONodeAddressWithLocation( neighbor.ParentRef, Stepper.GetParameters().VolumeNavigationData ), FSVONodeAddressWithLocation( neighbor.NodeRef, Stepper.GetParameters().VolumeNavigationData ), neighbor.TotalCost, false );
     DebugInfos.VisitedNodes++;
+
+    UE_LOG( LogSVODebugPathStepper, Verbose, TEXT( "OnProcessNeighbor From [%s] To [%s] with cost [%s]" ), *neighbor.ParentRef.ToString(), *neighbor.NodeRef.ToString(), *FString::SanitizeFloat( neighbor.TotalCost ) );
 }
 
 void FSVOPathFindingAStarObserver_GenerateDebugInfos::OnSearchSuccess( const ::TArray< FSVOPathFinderNodeAddressWithCost > & node_addresses )

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmTypes.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithmTypes.cpp
@@ -51,6 +51,19 @@ FSVOPathFindingParameters::FSVOPathFindingParameters( const FSVOVolumeNavigation
     CostCalculator( QueryFilterSettings.TraversalCostCalculator ),
     VolumeNavigationData( volume_navigation_data )
 {
-    VolumeNavigationData.GetNodeAddressFromPosition( StartNodeAddress, StartLocation );
-    VolumeNavigationData.GetNodeAddressFromPosition( EndNodeAddress, EndLocation );
+}
+
+TOptional< FSVOPathFindingParameters > FSVOPathFindingParameters::Initialize( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & start_location, const FVector & end_location, const FNavigationQueryFilter & nav_query_filter )
+{
+    auto result = FSVOPathFindingParameters( volume_navigation_data, start_location, end_location, nav_query_filter );
+
+    if ( volume_navigation_data.GetNodeAddressFromPosition( result.StartNodeAddress, start_location ) )
+    {
+        if ( volume_navigation_data.GetNodeAddressFromPosition( result.EndNodeAddress, end_location ) )
+        {
+            return result;
+        }
+    }
+
+    return TOptional< FSVOPathFindingParameters >();
 }

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_LazyThetaStar.cpp
@@ -25,8 +25,6 @@ ESVOPathFindingAlgorithmStepperStatus FSVOPathFindingAlgorithmStepper_LazyThetaS
 
     FillNodeAddressNeighbors( considered_node_unsafe->NodeRef );
 
-    const auto heuristic_scale = Parameters.NavigationQueryFilter.GetHeuristicScale();
-
     if ( considered_node_unsafe->ParentNodeIndex != INDEX_NONE && !HasLineOfSight( considered_node_unsafe->ParentRef, considered_node_unsafe->NodeRef ) )
     {
         auto min_traversal_cost = TNumericLimits< float >::Max();

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
@@ -139,7 +139,25 @@ bool FSVOPathFindingAlgorithmStepper_ThetaStar::HasLineOfSight( const FSVONodeAd
         ray_caster = GetDefault< USVONavigationSettings >()->DefaultRaycasterClass->GetDefaultObject< USVORayCaster >();
     }
 
-    return !ray_caster->Trace( Parameters.VolumeNavigationData, from, to );
+    const auto get_adjusted_position = [ this ]( const FSVONodeAddress & address ) {
+        if ( address == Parameters.StartNodeAddress )
+        {
+            return Parameters.StartLocation;
+        }
+        if ( address == Parameters.EndNodeAddress )
+        {
+            return Parameters.EndLocation;
+        }
+        return Parameters.VolumeNavigationData.GetNodePositionFromAddress( address, true );
+    };
+
+    const auto from_position = get_adjusted_position( from );
+    const auto to_position = get_adjusted_position( to );
+
+    const auto result = !ray_caster->Trace( Parameters.VolumeNavigationData, from_position, to_position );
+
+
+    return result;
 }
 
 ENavigationQueryResult::Type USVOPathFindingAlgorithmThetaStar::GetPath( FSVONavigationPath & navigation_path, const FSVOPathFindingParameters & params ) const

--- a/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
+++ b/Source/SVONavigation/Private/PathFinding/SVOPathFindingAlgorithm_ThetaStar.cpp
@@ -5,8 +5,8 @@
 #include "SVONavigationData.h"
 #include "SVONavigationSettings.h"
 
-FSVOPathFindingAlgorithmStepper_ThetaStar_Parameters::FSVOPathFindingAlgorithmStepper_ThetaStar_Parameters() :
-    RayCaster( NewObject< USVORayCaster_OctreeTraversal >() )
+FSVOPathFindingAlgorithmStepper_ThetaStar_Parameters::FSVOPathFindingAlgorithmStepper_ThetaStar_Parameters():
+    RayCaster( nullptr )
 {
 }
 

--- a/Source/SVONavigation/Private/Raycasters/SVORaycaster.cpp
+++ b/Source/SVONavigation/Private/Raycasters/SVORaycaster.cpp
@@ -3,7 +3,6 @@
 #include "SVONavigationData.h"
 #include "SVOVolumeNavigationData.h"
 
-#include <NavigationSystem.h>
 
 FSVORayCasterObserver_GenerateDebugInfos::FSVORayCasterObserver_GenerateDebugInfos( FSVORayCasterDebugInfos & debug_infos ) :
     DebugInfos( debug_infos )
@@ -35,14 +34,6 @@ void FSVORayCasterObserver_GenerateDebugInfos::AddTraversedLeafSubNode( FSVONode
 {
     UE_LOG( LogTemp, Warning, TEXT( "SubNode Address : %i - %i - %i" ), node_address.LayerIndex, node_address.NodeIndex, node_address.SubNodeIndex );
     DebugInfos.TraversedLeafSubNodes.Emplace( node_address, is_occluded );
-}
-
-bool USVORayCaster::Trace( const FSVOVolumeNavigationData & volume_navigation_data, const FSVONodeAddress from, const FSVONodeAddress to ) const
-{
-    const auto from_position = volume_navigation_data.GetNodePositionFromAddress( from, true );
-    const auto to_position = volume_navigation_data.GetNodePositionFromAddress( to, true );
-
-    return Trace( volume_navigation_data, from_position, to_position );
 }
 
 bool USVORayCaster::Trace( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & from, const FVector & to ) const

--- a/Source/SVONavigation/Private/SVONavDataRenderingComponent.cpp
+++ b/Source/SVONavigation/Private/SVONavDataRenderingComponent.cpp
@@ -167,24 +167,26 @@ void FSVONavigationMeshSceneProxy::AddNodeTextInfos( const MortonCode node_morto
 {
     const auto & debug_infos = NavigationData->GetDebugInfos();
 
+    static constexpr float vertical_offset_increment = 40.0f;
+
     auto vertical_offset = 0.0f;
     if ( debug_infos.bDebugDrawMortonCoords )
     {
         Texts.Emplace( FString::Printf( TEXT( "%i:%llu" ), node_layer_index, node_morton_code ), node_position, FLinearColor::Black );
-        vertical_offset += 40.0f;
+        vertical_offset += vertical_offset_increment;
     }
     if ( debug_infos.bDebugDrawNodeCoords )
     {
         const FIntVector morton_coords = FIntVector( FSVOHelpers::GetVectorFromMortonCode( node_morton_code ) );
         Texts.Emplace( FString::Printf( TEXT( "%s" ), *morton_coords.ToString() ), node_position + FVector( 0.0f, 0.0f, vertical_offset ), FLinearColor::Black );
-        vertical_offset += 40.0f;
+        vertical_offset += vertical_offset_increment;
     }
     if ( debug_infos.bDebugDrawNodeAddresses )
     {
         const FSVONodeAddress node_address( node_layer_index, node_morton_code );
 
         Texts.Emplace( FString::Printf( TEXT( "%s" ), *node_address.ToString() ), node_position + FVector( 0.0f, 0.0f, vertical_offset ), FLinearColor::Black );
-        vertical_offset += 40.0f;
+        vertical_offset += vertical_offset_increment;
     }
     if ( debug_infos.bDebugDrawNodeLocation )
     {

--- a/Source/SVONavigation/Private/SVONavDataRenderingComponent.cpp
+++ b/Source/SVONavigation/Private/SVONavDataRenderingComponent.cpp
@@ -21,7 +21,7 @@ static const FColor FreeVoxelColor = FColor::Green;
 FSVONavigationMeshSceneProxy::FSVONavigationMeshSceneProxy( const UPrimitiveComponent * component ) :
     FDebugRenderSceneProxy( component )
 {
-    DrawType = EDrawType::SolidAndWireMeshes;
+    DrawType = EDrawType::WireMesh;
 
     RenderingComponent = MakeWeakObjectPtr( const_cast< USVONavDataRenderingComponent * >( Cast< USVONavDataRenderingComponent >( component ) ) );
     NavigationData = MakeWeakObjectPtr( Cast< ASVONavigationData >( RenderingComponent->GetOwner() ) );

--- a/Source/SVONavigation/Private/SVONavigationData.cpp
+++ b/Source/SVONavigation/Private/SVONavigationData.cpp
@@ -22,14 +22,16 @@
 
 FSVOVolumeNavigationDataDebugInfos::FSVOVolumeNavigationDataDebugInfos() :
     bDebugDrawBounds( false ),
-    bDebugDrawNodeAddress( false ),
+    bDebugDrawNodeCoords( false ),
     bDebugDrawMortonCoords( false ),
+    bDebugDrawNodeAddresses( false ),
     bDebugDrawNodeLocation( false ),
     bDebugDrawLayers( false ),
     LayerIndexToDraw( 0 ),
     bDebugDrawSubNodes( false ),
     bDebugDrawOccludedVoxels( true ),
     bDebugDrawFreeVoxels( false ),
+    bDebugDrawNeighborLinks( false ),
     bDebugDrawActivePaths( false )
 {
 }

--- a/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
+++ b/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
@@ -43,27 +43,27 @@ void FSVONavigationDataGenerator::Init()
     MaximumGeneratorTaskCount = FMath::Min( FMath::Max( worker_threads_count * 2, 1 ), NavigationData.MaxSimultaneousBoxGenerationJobsCount );
     UE_LOG( LogNavigation, Log, TEXT( "Using max of %d workers to build SVO navigation." ), MaximumGeneratorTaskCount );
 
-    //IsInitialized = true;
+    // IsInitialized = true;
 
     //// recreate navmesh if no data was loaded, or when loaded data doesn't match current grid layout
-    //bool must_create_navigation_data = true;
-    //const bool is_static_navigation_data = IsStaticNavigationData( NavigationData );
+    // bool must_create_navigation_data = true;
+    // const bool is_static_navigation_data = IsStaticNavigationData( NavigationData );
 
-    //if ( is_static_navigation_data )
+    // if ( is_static_navigation_data )
     //{
-    //    must_create_navigation_data = false;
-    //}
-    //else
+    //     must_create_navigation_data = false;
+    // }
+    // else
     //{
-    //    // :TODO: ?
-    //};
+    //     // :TODO: ?
+    // };
 
-    //if ( must_create_navigation_data )
+    // if ( must_create_navigation_data )
     //{
-    //    // :TODO:
-    //    //ConstructSVOData();
-    //    MarkNavBoundsDirty();
-    //}
+    //     // :TODO:
+    //     //ConstructSVOData();
+    //     MarkNavBoundsDirty();
+    // }
 }
 
 bool FSVONavigationDataGenerator::RebuildAll()
@@ -322,7 +322,7 @@ TArray< FBox > FSVONavigationDataGenerator::ProcessAsyncTasks( const int32 task_
 
     for ( int32 index = RunningBoundsDataGenerationElements.Num() - 1; index >= 0; --index )
     {
-        //QUICK_SCOPE_CYCLE_COUNTER( STAT_RecastNavMeshGenerator_ProcessTileTasks_FinishedTasks );
+        // QUICK_SCOPE_CYCLE_COUNTER( STAT_RecastNavMeshGenerator_ProcessTileTasks_FinishedTasks );
 
         FRunningBoundsDataGenerationElement & element = RunningBoundsDataGenerationElements[ index ];
         check( element.AsyncTask != nullptr );
@@ -351,7 +351,7 @@ TArray< FBox > FSVONavigationDataGenerator::ProcessAsyncTasks( const int32 task_
     const bool has_tasks_at_end = GetNumRemaningBuildTasks() > 0;
     if ( has_tasks_at_start && !has_tasks_at_end )
     {
-        //QUICK_SCOPE_CYCLE_COUNTER( STAT_RecastNavMeshGenerator_OnNavMeshGenerationFinished );
+        // QUICK_SCOPE_CYCLE_COUNTER( STAT_RecastNavMeshGenerator_OnNavMeshGenerationFinished );
         NavigationData.OnNavigationDataGenerationFinished();
     }
 
@@ -360,7 +360,7 @@ TArray< FBox > FSVONavigationDataGenerator::ProcessAsyncTasks( const int32 task_
 
 TSharedRef< FSVOVolumeNavigationDataGenerator > FSVONavigationDataGenerator::CreateBoxNavigationGenerator( const FBox & box )
 {
-    //SCOPE_CYCLE_COUNTER(STAT_SVONavigation_CreateBoxNavigationGenerator);
+    // SCOPE_CYCLE_COUNTER(STAT_SVONavigation_CreateBoxNavigationGenerator);
 
     TSharedRef< FSVOVolumeNavigationDataGenerator > box_navigation_data_generator = MakeShareable( new FSVOVolumeNavigationDataGenerator( *this, box ) );
     return box_navigation_data_generator;

--- a/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
+++ b/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
@@ -204,9 +204,9 @@ void FSVONavigationDataGenerator::GetSeedLocations( TArray< FVector2D > & seed_l
     // Collect players positions
     for ( FConstPlayerControllerIterator player_iterator = world.GetPlayerControllerIterator(); player_iterator; ++player_iterator )
     {
-        if ( APlayerController * player_controller = player_iterator->Get() )
+        if ( const auto * player_controller = player_iterator->Get() )
         {
-            if ( auto * pawn = player_controller->GetPawn() )
+            if ( const auto * pawn = player_controller->GetPawn() )
             {
                 const FVector2D seed_location( pawn->GetActorLocation() );
                 seed_locations.Add( seed_location );

--- a/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
+++ b/Source/SVONavigation/Private/SVONavigationDataGenerator.cpp
@@ -262,8 +262,10 @@ void FSVONavigationDataGenerator::UpdateNavigationBounds()
                     bounds_sum += box;
                 }
 
+                // :NOTE: Commented because starting in UE5 or UE5.1 it will always remove all nav data
+                // Can be removed later when it's sure this can be dropped
                 // Remove the existing navigation bounds which don't match the new navigation bounds
-                NavigationData.RemoveDataInBounds( RegisteredNavigationBounds );
+                // NavigationData.RemoveDataInBounds( RegisteredNavigationBounds );
             }
             TotalNavigationBounds = bounds_sum;
         }

--- a/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
+++ b/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
@@ -61,7 +61,8 @@ FVector FSVOVolumeNavigationData::GetNodePositionFromAddress( const FSVONodeAddr
     const auto & layer = SVOData.GetLayer( address.LayerIndex );
     const auto layer_node_size = layer.GetNodeSize();
     const auto layer_node_extent = layer.GetNodeExtent();
-    const auto morton_coords = FSVOHelpers::GetVectorFromMortonCode( address.NodeIndex );
+    const auto & node = layer.GetNode( address.NodeIndex );
+    const auto morton_coords = FSVOHelpers::GetVectorFromMortonCode( node.MortonCode );
 
     const auto position = navigation_bounds_center - navigation_bounds_extent + morton_coords * layer_node_size + layer_node_extent;
 
@@ -483,12 +484,12 @@ void FSVOVolumeNavigationData::FirstPassRasterization()
     {
         const auto & layer = SVOData.GetLayer( 1 );
         const auto layer_max_node_count = layer.GetMaxNodeCount();
-        const auto layer_node_extent = layer.GetNodeExtent();
+        const auto layer_node_extent = layer.GetNodeExtent();        
 
         for ( MortonCode node_index = 0; node_index < layer_max_node_count; ++node_index )
         {
-            const auto position = GetNodePositionFromAddress( FSVONodeAddress( 1, node_index ), false );
-
+            const auto position = GetNodePositionFromLayerAndMortonCode( 1, node_index );
+            
             if ( IsPositionOccluded( position, layer_node_extent ) )
             {
                 SVOData.AddBlockedNode( 0, node_index );

--- a/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
+++ b/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
@@ -68,6 +68,24 @@ FVector FSVOVolumeNavigationData::GetNodePositionFromAddress( const FSVONodeAddr
     return position;
 }
 
+FVector FSVOVolumeNavigationData::GetNodePositionFromLayerAndMortonCode( const LayerIndex layer_index, const MortonCode morton_code ) const
+{
+    if ( layer_index == 0 )
+    {
+        return GetLeafNodePositionFromMortonCode( morton_code );
+    }
+
+    const auto & layer = SVOData.GetLayer( layer_index );
+    const auto layer_node_extent = layer.GetNodeExtent();
+    const auto & navigation_bounds = SVOData.GetNavigationBounds();
+    const auto navigation_bounds_center = navigation_bounds.GetCenter();
+    const auto navigation_bounds_extent = navigation_bounds.GetExtent();
+    const auto layer_node_size = layer.GetNodeSize();
+    const auto morton_coords = FSVOHelpers::GetVectorFromMortonCode( morton_code );
+
+    return navigation_bounds_center - navigation_bounds_extent + morton_coords * layer_node_size + layer_node_extent;
+}
+
 FVector FSVOVolumeNavigationData::GetLeafNodePositionFromMortonCode( const MortonCode morton_code ) const
 {
     const auto & navigation_bounds = SVOData.GetNavigationBounds();

--- a/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
+++ b/Source/SVONavigation/Private/SVOVolumeNavigationData.cpp
@@ -323,6 +323,8 @@ void FSVOVolumeNavigationData::GetNodeNeighbors( TArray< FSVONodeAddress > & nei
                     auto first_child_address = neighbor.FirstChild;
                     const auto & leaf_node = SVOData.GetLeafNodes().GetLeafNode( first_child_address.NodeIndex );
 
+                    first_child_address.LayerIndex = 0;
+                    first_child_address.NodeIndex = this_address.NodeIndex;
                     first_child_address.SubNodeIndex = leaf_index;
 
                     if ( !leaf_node.IsSubNodeOccluded( leaf_index ) )

--- a/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithmTypes.h
+++ b/Source/SVONavigation/Public/PathFinding/SVOPathFindingAlgorithmTypes.h
@@ -78,11 +78,17 @@ struct SVONAVIGATION_API FSVOPathFinderDebugInfos
 
     UPROPERTY( VisibleAnywhere )
     float PathLength;
+
+    UPROPERTY( VisibleAnywhere )
+    FString StartNodeAddress;
+
+    UPROPERTY( VisibleAnywhere )
+    FString EndNodeAddress;
 };
 
 struct FSVOPathFindingParameters
 {
-    FSVOPathFindingParameters( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & start_location, const FVector & end_location, const FNavigationQueryFilter & nav_query_filter );
+    static TOptional< FSVOPathFindingParameters > Initialize( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & start_location, const FVector & end_location, const FNavigationQueryFilter & nav_query_filter );
 
     FVector StartLocation;
     FVector EndLocation;
@@ -94,4 +100,7 @@ struct FSVOPathFindingParameters
     const FSVOVolumeNavigationData & VolumeNavigationData;
     FSVONodeAddress StartNodeAddress;
     FSVONodeAddress EndNodeAddress;
+
+private:
+    FSVOPathFindingParameters( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & start_location, const FVector & end_location, const FNavigationQueryFilter & nav_query_filter );
 };

--- a/Source/SVONavigation/Public/Raycasters/SVORaycaster.h
+++ b/Source/SVONavigation/Public/Raycasters/SVORaycaster.h
@@ -61,7 +61,6 @@ class SVONAVIGATION_API USVORayCaster : public UObject
     GENERATED_BODY()
 
 public:
-    bool Trace( const FSVOVolumeNavigationData & volume_navigation_data, const FSVONodeAddress from, const FSVONodeAddress to ) const;
     bool Trace( const FSVOVolumeNavigationData & volume_navigation_data, const FVector & from, const FVector & to ) const;
 
     void SetObserver( TSharedPtr< FSVORayCasterObserver > observer );

--- a/Source/SVONavigation/Public/SVONavDataRenderingComponent.h
+++ b/Source/SVONavigation/Public/SVONavDataRenderingComponent.h
@@ -19,7 +19,10 @@ public:
     virtual ~FSVONavigationMeshSceneProxy() override;
 
     SIZE_T GetTypeHash() const override;
+
 protected:
+    bool AddVoxelToBoxes( const FVector & voxel_location, const float node_extent, const bool is_occluded );
+    void AddNodeTextInfos( const MortonCode node_morton_code, const LayerIndex node_layer_index, const FVector & node_position );
     FPrimitiveViewRelevance GetViewRelevance( const FSceneView * view ) const override;
     TWeakObjectPtr< USVONavDataRenderingComponent > RenderingComponent;
     TWeakObjectPtr< ASVONavigationData > NavigationData;

--- a/Source/SVONavigation/Public/SVONavDataRenderingComponent.h
+++ b/Source/SVONavigation/Public/SVONavDataRenderingComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "SVONavigationTypes.h"
+
 #include <Components/PrimitiveComponent.h>
 #include <CoreMinimal.h>
 #include <DebugRenderSceneProxy.h>
@@ -23,6 +25,8 @@ public:
 protected:
     bool AddVoxelToBoxes( const FVector & voxel_location, const float node_extent, const bool is_occluded );
     void AddNodeTextInfos( const MortonCode node_morton_code, const LayerIndex node_layer_index, const FVector & node_position );
+    void DrawNeighborInfos( const FSVOVolumeNavigationData & navigation_bounds_data, const FSVONodeAddress & node_address );
+
     FPrimitiveViewRelevance GetViewRelevance( const FSceneView * view ) const override;
     TWeakObjectPtr< USVONavDataRenderingComponent > RenderingComponent;
     TWeakObjectPtr< ASVONavigationData > NavigationData;

--- a/Source/SVONavigation/Public/SVONavigationData.h
+++ b/Source/SVONavigation/Public/SVONavigationData.h
@@ -23,10 +23,13 @@ struct SVONAVIGATION_API FSVOVolumeNavigationDataDebugInfos
     uint8 bDebugDrawBounds : 1;
 
     UPROPERTY( EditInstanceOnly )
-    uint8 bDebugDrawNodeAddress : 1;
+    uint8 bDebugDrawNodeCoords: 1;
 
     UPROPERTY( EditInstanceOnly )
     uint8 bDebugDrawMortonCoords : 1;
+
+    UPROPERTY( EditInstanceOnly )
+    uint8 bDebugDrawNodeAddresses: 1;
 
     UPROPERTY( EditInstanceOnly )
     uint8 bDebugDrawNodeLocation : 1;
@@ -45,6 +48,12 @@ struct SVONAVIGATION_API FSVOVolumeNavigationDataDebugInfos
 
     UPROPERTY( EditInstanceOnly )
     uint8 bDebugDrawFreeVoxels : 1;
+
+    UPROPERTY( EditInstanceOnly )
+    uint8 bDebugDrawNeighborLinks : 1;
+
+    UPROPERTY( EditInstanceOnly )
+    FString NeighborLinksForNodeAddress;
 
     UPROPERTY( EditInstanceOnly )
     uint8 bDebugDrawActivePaths : 1;

--- a/Source/SVONavigation/Public/SVONavigationData.h
+++ b/Source/SVONavigation/Public/SVONavigationData.h
@@ -155,6 +155,7 @@ public:
     void UpdateNavVersion();
 
 private:
+    void SerializeSVOData( FArchive & archive, ESVOVersion version );
     void CheckToDiscardSubLevelNavData( const UNavigationSystemBase & navigation_system );
     void RecreateDefaultFilter() const;
     void UpdateDrawing() const;

--- a/Source/SVONavigation/Public/SVONavigationData.h
+++ b/Source/SVONavigation/Public/SVONavigationData.h
@@ -59,6 +59,30 @@ struct SVONAVIGATION_API FSVOVolumeNavigationDataDebugInfos
     uint8 bDebugDrawActivePaths : 1;
 };
 
+USTRUCT()
+struct SVONAVIGATION_API FSVONavigationDataInfos
+{
+    GENERATED_USTRUCT_BODY()
+
+    UPROPERTY( VisibleInstanceOnly )
+    FVector VolumeLocation;
+
+    UPROPERTY( VisibleInstanceOnly )
+    uint8 bHasNavigationData : 1;
+
+    UPROPERTY( VisibleInstanceOnly )
+    int LayerCount;
+};
+
+USTRUCT()
+struct SVONAVIGATION_API FSVODataInfos
+{
+    GENERATED_USTRUCT_BODY()
+
+    UPROPERTY( EditInstanceOnly )
+    TArray< FSVONavigationDataInfos > Infos;
+};
+
 UCLASS( config = Engine, defaultconfig, hidecategories = ( Input, Physics, Collisions, Lighting, Rendering, Tags, "Utilities|Transformation", Actor, Layers, Replication ), notplaceable )
 class SVONAVIGATION_API ASVONavigationData final : public ANavigationData
 {
@@ -149,8 +173,11 @@ private:
 
     static FPathFindingResult FindPath( const FNavAgentProperties & agent_properties, const FPathFindingQuery & path_finding_query );
 
-    UPROPERTY( EditAnywhere, config, Category = "Display" )
+    UPROPERTY( EditInstanceOnly, Category = "Display" )
     FSVOVolumeNavigationDataDebugInfos DebugInfos;
+
+    UPROPERTY( VisibleInstanceONly, Category = "Display" )
+    FSVODataInfos DataInfos;
 
     UPROPERTY( EditAnywhere, config, Category = "Generation" )
     FSVODataGenerationSettings GenerationSettings;

--- a/Source/SVONavigation/Public/SVONavigationTypes.h
+++ b/Source/SVONavigation/Public/SVONavigationTypes.h
@@ -83,6 +83,11 @@ struct FSVONodeAddress
         return static_cast< NavNodeRef >( address );
     }
 
+    FString ToString() const
+    {
+        return FString::Printf( TEXT( "%i %i %i" ), LayerIndex, NodeIndex, SubNodeIndex );
+    }
+
     static const FSVONodeAddress InvalidAddress;
 
     uint8 LayerIndex        : 4;

--- a/Source/SVONavigation/Public/SVOVolumeNavigationData.h
+++ b/Source/SVONavigation/Public/SVOVolumeNavigationData.h
@@ -41,6 +41,7 @@ public:
     void SetVolumeNavigationQueryFilter( TSubclassOf< USVONavigationQueryFilter > navigation_query_filter );
 
     FVector GetNodePositionFromAddress( const FSVONodeAddress & address, bool try_get_sub_node_position ) const;
+    FVector GetNodePositionFromLayerAndMortonCode( LayerIndex layer_index, MortonCode morton_code ) const;
     FVector GetLeafNodePositionFromMortonCode( MortonCode morton_code ) const;
     bool GetNodeAddressFromPosition( FSVONodeAddress & node_address, const FVector & position ) const;
     void GetNodeNeighbors( TArray< FSVONodeAddress > & neighbors, const FSVONodeAddress & node_address ) const;


### PR DESCRIPTION
Fixed invalid node addresses when requesting the neighbors of a node
Fixed some debug visualization issues
Added a new debug visualization to display neighbors of any node
Fixed crashes when trying to generate a path with invalid locations
Fixed path constructed by the pathfinder observer to not add the node containing the start location as the first location
Fixed line of sight checks in the (lazy) theta pathfinding algorithms, that would trace from the node containing the start location and not from the start location itself
Fixed crash with Live Coding
Fixed serialization of the nav data
